### PR TITLE
SP2-561 - Enforce handover codes and context IDs to use UUID type for validation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/context/controller/HandoverContextController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/context/controller/HandoverContextController.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.cont
 import uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.context.request.UpdateHandoverContextRequest
 import uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.context.service.GetHandoverContextResult
 import uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.context.service.HandoverContextService
+import java.util.UUID
 
 @RestController
 @RequestMapping("\${app.self.endpoints.context}")
@@ -48,7 +49,7 @@ class HandoverContextController(
     ],
   )
   fun updateContext(
-    @Parameter(description = "Handover session ID") @PathVariable handoverSessionId: String,
+    @Parameter(description = "Handover session ID") @PathVariable handoverSessionId: UUID,
     @RequestBody @Valid handoverContext: UpdateHandoverContextRequest,
   ): ResponseEntity<Any> {
     return when (val result = handoverContextService.updateContext(handoverSessionId, handoverContext)) {
@@ -80,7 +81,7 @@ class HandoverContextController(
     ],
   )
   fun getContextByHandoverSessionId(
-    @Parameter(description = "Handover session ID") @PathVariable handoverSessionId: String,
+    @Parameter(description = "Handover session ID") @PathVariable handoverSessionId: UUID,
   ): ResponseEntity<Any> {
     return when (val result = handoverContextService.getContext(handoverSessionId)) {
       is GetHandoverContextResult.Success ->
@@ -111,7 +112,7 @@ class HandoverContextController(
     ],
   )
   fun getContextByAuthentication(): ResponseEntity<Any> {
-    val handoverSessionId: String = SecurityContextHolder.getContext().authentication.name
+    val handoverSessionId: UUID = UUID.fromString(SecurityContextHolder.getContext().authentication.name)
     return when (val result = handoverContextService.getContext(handoverSessionId)) {
       is GetHandoverContextResult.Success ->
         ResponseEntity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/context/entity/HandoverContext.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/context/entity/HandoverContext.kt
@@ -10,6 +10,7 @@ import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.util.UUID
 
 enum class UserAccess(val value: String) {
   READ_ONLY("READ_ONLY"),
@@ -26,7 +27,7 @@ enum class UserAccess(val value: String) {
 
 @RedisHash("HandoverContext")
 data class HandoverContext(
-  @Id @Indexed var handoverSessionId: String,
+  @Id @Indexed var handoverSessionId: UUID,
   val createdAt: LocalDateTime = LocalDateTime.now(),
   val principal: HandoverPrincipal,
   val subject: SubjectDetails,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/context/repository/HandoverContextRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/context/repository/HandoverContextRepository.kt
@@ -3,8 +3,9 @@ package uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.con
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.context.entity.HandoverContext
+import java.util.UUID
 
 @Repository
-interface HandoverContextRepository : CrudRepository<HandoverContext, String?> {
-  fun findByHandoverSessionId(handoverSessionId: String): HandoverContext?
+interface HandoverContextRepository : CrudRepository<HandoverContext, UUID?> {
+  fun findByHandoverSessionId(handoverSessionId: UUID): HandoverContext?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/context/service/HandoverContextService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/context/service/HandoverContextService.kt
@@ -4,13 +4,14 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.context.entity.HandoverContext
 import uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.context.repository.HandoverContextRepository
 import uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.context.request.UpdateHandoverContextRequest
+import java.util.UUID
 
 @Service
 class HandoverContextService(
   private val handoverContextRepository: HandoverContextRepository,
 ) {
 
-  fun updateContext(handoverSessionId: String, handoverContext: UpdateHandoverContextRequest): GetHandoverContextResult {
+  fun updateContext(handoverSessionId: UUID, handoverContext: UpdateHandoverContextRequest): GetHandoverContextResult {
     return handoverContextRepository.findByHandoverSessionId(handoverSessionId)
       ?.let {
         val updatedContext = it.copy(
@@ -29,7 +30,7 @@ class HandoverContextService(
     return handoverContextRepository.save(handoverContext)
   }
 
-  fun getContext(handoverSessionId: String): GetHandoverContextResult {
+  fun getContext(handoverSessionId: UUID): GetHandoverContextResult {
     return handoverContextRepository.findByHandoverSessionId(handoverSessionId)
       ?.let { GetHandoverContextResult.Success(it) }
       ?: GetHandoverContextResult.NotFound

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/handover/controller/HandoverController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/handover/controller/HandoverController.kt
@@ -97,7 +97,7 @@ class HandoverController(
     val client = appConfiguration.clients[clientId]
       ?: return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Client not found")
 
-    return when (val result = handoverService.consumeAndExchangeHandover(handoverCode.toString())) {
+    return when (val result = handoverService.consumeAndExchangeHandover(handoverCode)) {
       is UseHandoverLinkResult.Success -> {
         strategy.context = strategy.createEmptyContext()
         strategy.context.authentication = result.authenticationToken

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/handover/entity/HandoverToken.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/handover/entity/HandoverToken.kt
@@ -11,11 +11,11 @@ enum class TokenStatus {
   UNUSED,
 }
 
-@RedisHash("HandoverToken", timeToLive = 43200)
+@RedisHash("HandoverToken", timeToLive = 600)
 data class HandoverToken(
-  @Id var code: String = UUID.randomUUID().toString(),
+  @Id var code: UUID = UUID.randomUUID(),
   var tokenStatus: TokenStatus = TokenStatus.UNUSED,
   var createdAt: Instant = Instant.now(),
-  var handoverSessionId: String,
+  var handoverSessionId: UUID,
   var principal: HandoverPrincipal,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/handover/repository/HandoverTokenRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/handover/repository/HandoverTokenRepository.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.han
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.handover.entity.HandoverToken
+import java.util.UUID
 
 @Repository
-interface HandoverTokenRepository : CrudRepository<HandoverToken, String?>
+interface HandoverTokenRepository : CrudRepository<HandoverToken, UUID?>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/handover/response/CreateHandoverLinkResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/handover/response/CreateHandoverLinkResponse.kt
@@ -1,9 +1,10 @@
 package uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.handover.response
 
 import java.io.Serializable
+import java.util.UUID
 
 class CreateHandoverLinkResponse(
   val handoverLink: String,
-  val handoverSessionId: String,
+  val handoverSessionId: UUID,
   val link: String,
 ) : Serializable

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/handover/service/HandoverService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/handover/service/HandoverService.kt
@@ -30,7 +30,7 @@ class HandoverService(
 ) {
   fun createHandover(
     handoverRequest: CreateHandoverLinkRequest,
-    handoverSessionId: String = UUID.randomUUID().toString(),
+    handoverSessionId: UUID = UUID.randomUUID(),
   ): CreateHandoverLinkResponse {
     val handoverToken = HandoverToken(
       handoverSessionId = handoverSessionId,
@@ -61,7 +61,7 @@ class HandoverService(
     )
   }
 
-  fun consumeAndExchangeHandover(handoverCode: String): UseHandoverLinkResult {
+  fun consumeAndExchangeHandover(handoverCode: UUID): UseHandoverLinkResult {
     return when (validateToken(handoverCode)) {
       TokenValidationResult.NOT_FOUND -> UseHandoverLinkResult.HandoverLinkNotFound
       TokenValidationResult.ALREADY_USED -> UseHandoverLinkResult.HandoverLinkAlreadyUsed
@@ -78,11 +78,11 @@ class HandoverService(
     }
   }
 
-  private fun generateHandoverLink(handoverCode: String): String {
+  private fun generateHandoverLink(handoverCode: UUID): String {
     return "${appConfiguration.self.externalUrl}${appConfiguration.self.endpoints.handover}/$handoverCode"
   }
 
-  private fun validateToken(code: String): TokenValidationResult {
+  private fun validateToken(code: UUID): TokenValidationResult {
     val token = handoverTokenRepository.findById(code).orElse(null)
       ?: return TokenValidationResult.NOT_FOUND
 
@@ -93,7 +93,7 @@ class HandoverService(
     return TokenValidationResult.VALID
   }
 
-  private fun consumeToken(code: String): HandoverToken {
+  private fun consumeToken(code: UUID): HandoverToken {
     val token = handoverTokenRepository.findById(code).orElse(null)
       ?: throw NoSuchElementException()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/context/HandoverContextServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/context/HandoverContextServiceTest.kt
@@ -29,14 +29,14 @@ class HandoverContextServiceTest {
   @Nested
   @DisplayName("updateContext")
   inner class UpdateContext {
-    private lateinit var handoverSessionId: String
+    private lateinit var handoverSessionId: UUID
     private lateinit var updateHandoverContextRequest: UpdateHandoverContextRequest
     private lateinit var existingContext: HandoverContext
     private lateinit var updatedContext: HandoverContext
 
     @BeforeEach
     fun setup() {
-      handoverSessionId = UUID.randomUUID().toString()
+      handoverSessionId = UUID.randomUUID()
       updateHandoverContextRequest = TestUtils.updateHandoverContextRequest()
       existingContext = TestUtils.createHandoverContext(handoverSessionId)
       updatedContext = existingContext.copy(
@@ -59,11 +59,12 @@ class HandoverContextServiceTest {
 
     @Test
     fun `should return not found when using invalid handover session id`() {
+      val invalidUUID = UUID.randomUUID()
       every { handoverContextRepository.findByHandoverSessionId(any()) } returns null
 
-      val result = handoverContextService.updateContext("invalid-session-id", updateHandoverContextRequest)
+      val result = handoverContextService.updateContext(invalidUUID, updateHandoverContextRequest)
 
-      verify { handoverContextRepository.findByHandoverSessionId(match { it == "invalid-session-id" }) }
+      verify { handoverContextRepository.findByHandoverSessionId(match { it == invalidUUID }) }
       assertEquals(result, GetHandoverContextResult.NotFound)
     }
 
@@ -94,12 +95,12 @@ class HandoverContextServiceTest {
   @Nested
   @DisplayName("getContext")
   inner class GetContext {
-    private lateinit var handoverSessionId: String
+    private lateinit var handoverSessionId: UUID
     private lateinit var existingContext: HandoverContext
 
     @BeforeEach
     fun setup() {
-      handoverSessionId = UUID.randomUUID().toString()
+      handoverSessionId = UUID.randomUUID()
       existingContext = TestUtils.createHandoverContext(handoverSessionId)
     }
 
@@ -115,11 +116,12 @@ class HandoverContextServiceTest {
 
     @Test
     fun `should return not found when using invalid handover session id`() {
+      val invalidUUID = UUID.randomUUID()
       every { handoverContextRepository.findByHandoverSessionId(any()) } returns null
 
-      val result = handoverContextService.getContext("invalid-session-id")
+      val result = handoverContextService.getContext(invalidUUID)
 
-      verify { handoverContextRepository.findByHandoverSessionId(match { it == "invalid-session-id" }) }
+      verify { handoverContextRepository.findByHandoverSessionId(match { it == invalidUUID }) }
       assertEquals(result, GetHandoverContextResult.NotFound)
     }
   }
@@ -127,12 +129,12 @@ class HandoverContextServiceTest {
   @Nested
   @DisplayName("saveContext")
   inner class SaveContext {
-    private lateinit var handoverSessionId: String
+    private lateinit var handoverSessionId: UUID
     private lateinit var handoverContext: HandoverContext
 
     @BeforeEach
     fun setup() {
-      handoverSessionId = UUID.randomUUID().toString()
+      handoverSessionId = UUID.randomUUID()
       handoverContext = TestUtils.createHandoverContext(handoverSessionId)
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/handover/HandoverServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/handover/HandoverServiceTest.kt
@@ -27,15 +27,15 @@ import kotlin.test.assertContains
 class HandoverServiceTest {
 
   private lateinit var handoverService: HandoverService
+  private lateinit var handoverSessionId: UUID
   private val handoverTokenRepository: HandoverTokenRepository = mockk()
   private val handoverContextService: HandoverContextService = mockk()
   private val appConfiguration = mockk<AppConfiguration>(relaxed = true)
-  private var handoverSessionId = "testSessionId"
 
   @BeforeEach
   fun setUp() {
     handoverService = HandoverService(handoverTokenRepository, handoverContextService, appConfiguration)
-    handoverSessionId = UUID.randomUUID().toString()
+    handoverSessionId = UUID.randomUUID()
   }
 
   @Nested
@@ -119,7 +119,7 @@ class HandoverServiceTest {
       verify {
         handoverTokenRepository.save(
           withArg {
-            assertEquals(it.code, result.handoverLink.substringAfterLast('/'))
+            assertEquals(it.code.toString(), result.handoverLink.substringAfterLast('/'))
           },
         )
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/integration/HandoverContextControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/integration/HandoverContextControllerTest.kt
@@ -32,7 +32,7 @@ class HandoverContextControllerTest : IntegrationTestBase() {
   inner class UpdateContext {
     @Test
     fun `should return okay when updating the handover context with HMPPS Auth client credentials token `() {
-      val handoverSessionId = UUID.randomUUID().toString()
+      val handoverSessionId = UUID.randomUUID()
       val oldHandoverContext = TestUtils.createHandoverContext(handoverSessionId)
       val newHandoverContext = TestUtils.createHandoverContext(handoverSessionId)
 
@@ -92,7 +92,7 @@ class HandoverContextControllerTest : IntegrationTestBase() {
 
     @Test
     fun `should return forbidden when updating the handover context with a HMPPS ARNS Handover access token`() {
-      val handoverSessionId = UUID.randomUUID().toString()
+      val handoverSessionId = UUID.randomUUID()
       val newHandoverContext = TestUtils.createHandoverContext(handoverSessionId)
 
       val response = webTestClient.post().uri("${appConfiguration.self.endpoints.context}/$handoverSessionId")
@@ -110,7 +110,7 @@ class HandoverContextControllerTest : IntegrationTestBase() {
 
     @Test
     fun `should return unauthorized when updating the handover context without authorization`() {
-      val handoverSessionId = UUID.randomUUID().toString()
+      val handoverSessionId = UUID.randomUUID()
       val newHandoverContext = TestUtils.createHandoverContext(handoverSessionId)
 
       webTestClient.post().uri("${appConfiguration.self.endpoints.context}/$handoverSessionId")
@@ -122,7 +122,7 @@ class HandoverContextControllerTest : IntegrationTestBase() {
 
     @Test
     fun `should return not found when updating the handover context but handover context does not exist`() {
-      val handoverSessionId = UUID.randomUUID().toString()
+      val handoverSessionId = UUID.randomUUID()
       val newHandoverContext = TestUtils.createHandoverContext(handoverSessionId)
 
       webTestClient.post().uri("${appConfiguration.self.endpoints.context}/$handoverSessionId")
@@ -139,7 +139,7 @@ class HandoverContextControllerTest : IntegrationTestBase() {
   inner class GetContextByHandoverSessionId {
     @Test
     fun `should return okay when getting the handover context with HMPPS Auth client credentials token`() {
-      val handoverSessionId = UUID.randomUUID().toString()
+      val handoverSessionId = UUID.randomUUID()
       val handoverContext = TestUtils.createHandoverContext(handoverSessionId)
 
       // Setup an initial handover context
@@ -173,7 +173,7 @@ class HandoverContextControllerTest : IntegrationTestBase() {
   inner class GetContextByAuthentication {
     @Test
     fun `should return okay when getting the handover context using a HMPPS ARNS Handover access token`() {
-      val handoverSessionId = UUID.randomUUID().toString()
+      val handoverSessionId = UUID.randomUUID()
       val handoverContext = TestUtils.createHandoverContext(handoverSessionId)
 
       // Setup an initial handover context
@@ -192,7 +192,7 @@ class HandoverContextControllerTest : IntegrationTestBase() {
 
     @Test
     fun `should return forbidden when updating the handover context using HMPPS Auth client credentials token `() {
-      val handoverSessionId = UUID.randomUUID().toString()
+      val handoverSessionId = UUID.randomUUID()
       val handoverContext = TestUtils.createHandoverContext(handoverSessionId)
 
       // Setup an initial handover context

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/integration/HandoverControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/integration/HandoverControllerTest.kt
@@ -56,7 +56,7 @@ class HandoverControllerTest : IntegrationTestBase() {
         .responseBody
 
       assertThat(response.handoverLink).startsWith(appConfiguration.self.externalUrl)
-      assertThat(response.handoverSessionId).isNotEmpty
+      assertThat(response.handoverSessionId).toString().isNotEmpty()
     }
 
     @Test
@@ -100,7 +100,7 @@ class HandoverControllerTest : IntegrationTestBase() {
       val response = webTestClient.post().uri(appConfiguration.self.endpoints.handover)
         .bodyValue(handoverRequest)
         .header("Content-Type", "application/json")
-        .header("Authorization", "Bearer ${jwtHelper.generateHandoverToken("123")}")
+        .header("Authorization", "Bearer ${jwtHelper.generateHandoverToken(UUID.randomUUID())}")
         .exchange()
         .expectStatus().isForbidden
         .expectBody(ErrorResponse::class.java)
@@ -133,7 +133,7 @@ class HandoverControllerTest : IntegrationTestBase() {
 
       val handoverToken = handoverTokenRepository.save(
         HandoverToken(
-          handoverSessionId = UUID.randomUUID().toString(),
+          handoverSessionId = UUID.randomUUID(),
           principal = TestUtils.createPrincipal(),
         ),
       )
@@ -166,7 +166,7 @@ class HandoverControllerTest : IntegrationTestBase() {
 
       val handoverToken = handoverTokenRepository.save(
         HandoverToken(
-          handoverSessionId = UUID.randomUUID().toString(),
+          handoverSessionId = UUID.randomUUID(),
           principal = TestUtils.createPrincipal(),
         ),
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/testUtils/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/testUtils/JwtAuthHelper.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.conf
 import uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.config.JwtIssuerProperties
 import uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.config.JwtProperties
 import java.util.Date
+import java.util.UUID
 
 @Component
 class JwtAuthHelper(
@@ -21,14 +22,14 @@ class JwtAuthHelper(
     return jwtProperties.issuers.find { it.issuerName == issuerName }
   }
 
-  fun generateHandoverToken(handoverSessionId: String, grantType: AuthorizationGrantType = AuthorizationGrantType.JWT_BEARER): String {
+  fun generateHandoverToken(handoverSessionId: UUID, grantType: AuthorizationGrantType = AuthorizationGrantType.JWT_BEARER): String {
     val hmppsHandover = getIssuerByIssuerName("HMPPS Handover")
       ?: throw IllegalStateException()
 
     val claimsSet = JWTClaimsSet.Builder()
       .issuer(hmppsHandover.issuerUri)
       .issueTime(Date())
-      .subject(handoverSessionId)
+      .subject(handoverSessionId.toString())
       .claim("grant_type", grantType.value)
       .expirationTime(Date(System.currentTimeMillis() + 3600 * 1000)) // 1 hour expiry
       .jwtID(WireMockExtension.KEY_ID)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/testUtils/TestUtils.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/testUtils/TestUtils.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.hand
 import uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.handover.entity.TokenStatus
 import uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.handover.request.CreateHandoverLinkRequest
 import java.time.LocalDate
+import java.util.UUID
 
 object TestUtils {
   private var faker: Faker = Faker()
@@ -28,7 +29,7 @@ object TestUtils {
     )
   }
 
-  fun createHandoverContext(handoverSessionId: String): HandoverContext {
+  fun createHandoverContext(handoverSessionId: UUID): HandoverContext {
     return HandoverContext(
       handoverSessionId = handoverSessionId,
       principal = createPrincipal(),
@@ -89,7 +90,7 @@ object TestUtils {
   fun createHandoverToken(status: TokenStatus): HandoverToken {
     return HandoverToken(
       tokenStatus = status,
-      handoverSessionId = "sessionId",
+      handoverSessionId = UUID.randomUUID(),
       principal = createPrincipal(),
     )
   }


### PR DESCRIPTION
Switch from using `string` type to `UUID` type so that Spring validates that the passed value for a handover code or handover session ID is actually a UUID. Should enforce sanitisation and validation of links to stop this being a potential attack vector