### PR TITLE
Modified additional return URL to enable Capita developer access

### DIFF
--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -12,7 +12,7 @@ generic-service:
     HMPPS_AUTH_BASE_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk"
     HMPPS_HANDOVER_BASE_URL: "https://arns-handover-service-test.hmpps.service.justice.gov.uk"
     OASYS_BASE_URL: "https://arns-oastub-test.hmpps.service.justice.gov.uk"
-    OASYS_RETURN_URLS: "https://arns-oastub-test.hmpps.service.justice.gov.uk,http://10.0.1,https://t2-b.oasys.service.justice.gov.uk,http://192.168.56.21:8080/ords"
+    OASYS_RETURN_URLS: "https://arns-oastub-test.hmpps.service.justice.gov.uk,http://10.0.1,https://t2-b.oasys.service.justice.gov.uk,http://192.168.56.21"
     COORDINATOR_API_BASE_URL: "https://arns-coordinator-api-test.hmpps.service.justice.gov.uk"
     CLIENT_SP_OAUTH_REDIRECT_URI: "https://sentence-plan-test.hmpps.service.justice.gov.uk/sign-in/callback"
     CLIENT_SP_HANDOVER_REDIRECT_URI: "https://sentence-plan-test.hmpps.service.justice.gov.uk/sign-in"


### PR DESCRIPTION
Dimitar spotted we might be better only including the URL prefix, theory being the / might be interpreted as an escape character.

Giving this a whirl with agreement from Capita to deploy over lunchtime.