### PR TITLE
Mod Platform Egress IPs added to Whitelist (trying IPs)

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -16,10 +16,12 @@ generic-service:
     CLIENT_SP_HANDOVER_REDIRECT_URI: "https://sentence-plan-preprod.hmpps.service.justice.gov.uk/sign-in"
     CLIENT_SAN_OAUTH_REDIRECT_URI: "https://strengths-based-needs-assessments-preprod.hmpps.service.justice.gov.uk/sign-in/callback"
     CLIENT_SAN_HANDOVER_REDIRECT_URI: "https://strengths-based-needs-assessments-preprod.hmpps.service.justice.gov.uk/sign-in"
-  
+
   allowlist:
-    groups:
-      - mod-platform-live
+    mod-platform-live-eu-west-2a-nat: 13.41.38.176/32
+    mod-platform-live-eu-west-2c-nat: 3.11.197.133/32
+    mod-platform-live-eu-west-2b-nat: 3.8.81.175/32
+    neil-tait-test-ip-remove-after-test: 51.155.102.238/32
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts


### PR DESCRIPTION
This change swaps in the actual IPs for Mod Platform as a test, instead of the group tag. It also has another personal developer machine IP to test the whitelist changes are taking effect.