### PR TITLE
Return urls mp egress

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -22,7 +22,6 @@ generic-service:
     mod-platform-live-eu-west-2a-nat: 13.41.38.176/32
     mod-platform-live-eu-west-2c-nat: 3.11.197.133/32
     mod-platform-live-eu-west-2b-nat: 3.8.81.175/32
-    neil-tait-test-ip-remove-after-test: 51.155.102.238/32
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -11,12 +11,18 @@ generic-service:
     HMPPS_AUTH_BASE_URL: "https://sign-in.hmpps.service.justice.gov.uk"
     HMPPS_HANDOVER_BASE_URL: "https://arns-handover-service.hmpps.service.justice.gov.uk"
     OASYS_BASE_URL: "https://oasys.service.justice.gov.uk"
+    OASYS_RETURN_URLS: "https://oasys.service.justice.gov.uk,https://int.oasys.service.justice.gov.uk"
     COORDINATOR_API_BASE_URL: "https://arns-coordinator-api.hmpps.service.justice.gov.uk"
     CLIENT_SP_OAUTH_REDIRECT_URI: "https://sentence-plan.hmpps.service.justice.gov.uk/sign-in/callback"
     CLIENT_SP_HANDOVER_REDIRECT_URI: "https://sentence-plan.hmpps.service.justice.gov.uk/sign-in"
     CLIENT_SAN_OAUTH_REDIRECT_URI: "https://strengths-based-needs-assessments.hmpps.service.justice.gov.uk/sign-in/callback"
     CLIENT_SAN_HANDOVER_REDIRECT_URI: "https://strengths-based-needs-assessments.hmpps.service.justice.gov.uk/sign-in"
-
+    
+  allowlist:
+    mod-platform-live-eu-west-2a-nat: 13.41.38.176/32
+    mod-platform-live-eu-west-2c-nat: 3.11.197.133/32
+    mod-platform-live-eu-west-2b-nat: 3.8.81.175/32
+    
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:


### PR DESCRIPTION
This change adds the OASys return URLs and Mod Platform egress IPs. 

It also removes an IP from the preprod configuration that was used during testing.