### PR TITLE
Modify 'SameSite' cookie attribute to 'Strict'

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,6 +71,7 @@ server:
     session:
       cookie:
         name: HMPPS_ARNS_HANDOVER_SESSION
+        same-site: strict
   forward-headers-strategy: native
   tomcat:
     remoteip:


### PR DESCRIPTION
This change updates the server to set the 'SameSite' cookie directive to 'Strict' which will ensure the user's session cookie is protected from session-hijack or CSRF attacks.