### PR TITLE
Add personal IP to replicate Capita issue.

### DIFF
--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -35,8 +35,7 @@ generic-service:
     capita-developers-vms-five: 85.115.54.180/32
     capita-developers-vms-six: 85.115.54.200/29
     oasys-box-t2 : 10.26.12.211/32
-    krupal-appsec: 80.195.27.199/32
-    kieran-accessibility: 5.181.59.114/32
+    neil-test: 51.155.102.238/32
 
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack


### PR DESCRIPTION
Adding personal IP address of Neil Tait to replicate fault reported by Capita regarding login/redirection issues.

Also removed 2 IPs that were used for App Sec and Accessibility testers.