### PR TITLE
Regress cookie change for Capita

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,7 +71,7 @@ server:
     session:
       cookie:
         name: HMPPS_ARNS_HANDOVER_SESSION
-        same-site: strict
+        same-site: lax
   forward-headers-strategy: native
   tomcat:
     remoteip:


### PR DESCRIPTION
Capita can't seem to access the service when we have SameSite=Strict, so we're regressing this change to unblock their testing, then we'll investigate the issue fully.