### PR TITLE
Fix renovate GitHub Actions config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,10 @@
     },
     {
       "matchManagers": ["github-actions"],
-      "fileMatch": ["^\\.github/workflows/.*\\.yml$"]
+      "matchFileNames": [
+        "**/.github/workflows/**/*.ya?ml",
+        "**/.github/actions/**/*.ya?ml"
+        ]
     }
   ]
 }


### PR DESCRIPTION
Updates `renovate.json` to replace deprecated `fileMatch` with `matchFileNames` for the GitHub Actions package rule.

This aligns with [Renovate's updated configuration options](https://docs.renovatebot.com/configuration-options/#matchfilenames).