### PR TITLE
Add retries to WebClientConfiguration

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       ALLOW_EMPTY_PASSWORD: yes
 
   hmpps-auth:
-    image: ghcr.io/ministryofjustice/hmpps-auth
+    image: ghcr.io/ministryofjustice/hmpps-auth:2026-01-19.282.b6537e8
     networks:
       - hmpps
     healthcheck:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/config/WebClientConfiguration.kt
@@ -1,17 +1,70 @@
 package uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.config
 
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.webclient.WebClientCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction
 import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+import reactor.util.retry.Retry
 import uk.gov.justice.hmpps.kotlin.auth.authorisedWebClient
+import java.io.IOException
 import java.time.Duration
+import java.util.concurrent.TimeoutException
 
 @Configuration
 class WebClientConfiguration(
-  @param:Value("\${app.services.coordinator-api.base-url}") val coordinatorApiUri: String,
-  @param:Value("\${api.timeout:20s}") val timeout: Duration,
+  @param:Value("\${app.services.coordinator-api.base-url}") private val coordinatorApiUri: String,
+  @param:Value("\${api.timeout:20s}") private val timeout: Duration,
+  @param:Value("\${api.retry.max-retries:2}") private val retryMaxRetries: Long,
+  @param:Value("\${api.retry.min-backoff:250ms}") private val retryMinBackoff: Duration,
 ) {
+  private val retryableStatusCodes = setOf(429, 502, 503, 504)
+
   @Bean
-  fun coordinatorApiWebClient(authorizedClientManager: org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager, builder: WebClient.Builder): WebClient = builder.authorisedWebClient(authorizedClientManager, registrationId = "coordinator-api", url = coordinatorApiUri, timeout)
+  fun retryingWebClientCustomizer(): WebClientCustomizer = WebClientCustomizer { builder ->
+    builder.filter(retryingExchangeFilterFunction())
+  }
+
+  @Bean
+  fun coordinatorApiWebClient(authorizedClientManager: org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager, builder: WebClient.Builder): WebClient = builder.authorisedWebClient(
+    authorizedClientManager,
+    registrationId = "coordinator-api",
+    url = coordinatorApiUri,
+    timeout,
+  )
+
+  internal fun retryingExchangeFilterFunction(): ExchangeFilterFunction = ExchangeFilterFunction { request, next ->
+    next.exchange(request)
+      .flatMap(::toRetryableResponse)
+      .retryWhen(createRetrySpec())
+  }
+
+  private fun toRetryableResponse(response: ClientResponse): Mono<ClientResponse> {
+    if (!retryableStatusCodes.contains(response.statusCode().value())) {
+      return Mono.just(response)
+    }
+
+    return response.createException().flatMap { exception -> Mono.error<ClientResponse>(exception) }
+  }
+
+  private fun createRetrySpec(): Retry = Retry
+    .backoff(retryMaxRetries, retryMinBackoff)
+    .jitter(0.5)
+    .filter(::isRetryableException)
+    .onRetryExhaustedThrow { _, signal -> signal.failure() }
+
+  private fun isRetryableException(exception: Throwable): Boolean {
+    if (exception is org.springframework.web.reactive.function.client.WebClientResponseException) {
+      return retryableStatusCodes.contains(exception.statusCode.value())
+    }
+
+    if (exception is org.springframework.web.reactive.function.client.WebClientRequestException || exception is IOException || exception is TimeoutException) {
+      return true
+    }
+
+    return exception.cause?.let(::isRetryableException) ?: false
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/coordinator/service/CoordinatorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/coordinator/service/CoordinatorService.kt
@@ -3,16 +3,12 @@ package uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.coo
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
-import uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.config.AppConfiguration
 import uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.coordinator.response.AssociationsResponse
 
 @Service
 class CoordinatorService(
-  val appConfiguration: AppConfiguration,
-  val coordinatorApiWebClient: WebClient,
+  private val coordinatorApiWebClient: WebClient,
 ) {
-  private fun endpoint(endpoint: String): String = "${appConfiguration.services.coordinatorApi.baseUrl}$endpoint"
-
   fun getAssociations(oasysAssessmentPk: String, planVersion: Long?): AssociationsResponse = try {
     val result = coordinatorApiWebClient.get()
       .uri { uriBuilder ->
@@ -27,8 +23,8 @@ class CoordinatorService(
     result
       ?: throw IllegalStateException("Unexpected empty associations response for OASys Assessment PK $oasysAssessmentPk")
   } catch (ex: WebClientResponseException) {
-    throw Exception("Unexpected associations response code ${ex.statusCode}")
+    throw Exception("Unexpected associations response code ${ex.statusCode}", ex)
   } catch (ex: Exception) {
-    throw Exception("Unexpected associations exception: ${ex.message}")
+    throw Exception("Unexpected associations exception: ${ex.message}", ex)
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,12 @@ logging:
       springframework:
         security: info
 
+api:
+  timeout: 5s
+  retry:
+    max-retries: 2
+    min-backoff: 250ms
+
 spring:
   session:
     timeout: 12h

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/config/WebClientConfigurationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/config/WebClientConfigurationTest.kt
@@ -62,7 +62,7 @@ class WebClientConfigurationTest {
                   """.trimIndent(),
                 )
                 .build(),
-              )
+            )
           }
         },
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/config/WebClientConfigurationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/config/WebClientConfigurationTest.kt
@@ -1,0 +1,115 @@
+package uk.gov.justice.digital.hmpps.hmppsassessrisksandneedshandoverservice.config
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.client.ClientRequest
+import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.ExchangeFunction
+import reactor.core.publisher.Mono
+import java.net.URI
+import java.time.Duration
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertContains
+import kotlin.test.assertFailsWith
+
+class WebClientConfigurationTest {
+  private val webClientConfiguration = WebClientConfiguration(
+    coordinatorApiUri = "http://localhost",
+    timeout = Duration.ofSeconds(5),
+    retryMaxRetries = 2,
+    retryMinBackoff = Duration.ofMillis(1),
+  )
+
+  @Nested
+  @DisplayName("retryingWebClientCustomizer")
+  inner class RetryingWebClientCustomizer {
+    @Test
+    fun `should retry when the downstream API returns a retryable status before succeeding`() {
+      val requestCount = AtomicInteger()
+      val expectedSentencePlanId = UUID.randomUUID()
+      val expectedAssessmentId = UUID.randomUUID()
+      val response = exchangeFilterFunction().filter(
+        clientRequest(),
+        ExchangeFunction {
+          Mono.defer {
+            val currentAttempt = requestCount.incrementAndGet()
+
+            if (currentAttempt < 3) {
+              return@defer Mono.just(
+                ClientResponse.create(HttpStatus.SERVICE_UNAVAILABLE)
+                  .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                  .body("""{"status":503}""")
+                  .build(),
+              )
+            }
+
+            Mono.just(
+              ClientResponse.create(HttpStatus.OK)
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .body(
+                  """
+                  {
+                    "sentencePlanId": "$expectedSentencePlanId",
+                    "sanAssessmentId": "$expectedAssessmentId",
+                    "planVersion": 7
+                  }
+                  """.trimIndent(),
+                )
+                .build(),
+              )
+          }
+        },
+      )
+      val result = response
+        .flatMap { clientResponse -> clientResponse.bodyToMono(TestAssociationsResponse::class.java) }
+        .block()
+
+      assertEquals(3, requestCount.get())
+      assertEquals(expectedSentencePlanId, result?.sentencePlanId)
+      assertEquals(expectedAssessmentId, result?.sanAssessmentId)
+      assertEquals(7, result?.planVersion)
+    }
+
+    @Test
+    fun `should not retry when the downstream API returns a bad request`() {
+      val requestCount = AtomicInteger()
+      val exception = assertFailsWith<Exception> {
+        exchangeFilterFunction().filter(
+          clientRequest(),
+          ExchangeFunction {
+            Mono.defer {
+              requestCount.incrementAndGet()
+              Mono.just(
+                ClientResponse.create(HttpStatus.BAD_REQUEST)
+                  .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                  .body("""{"status":400}""")
+                  .build(),
+              )
+            }
+          },
+        ).flatMap { clientResponse ->
+          clientResponse.createException().flatMap { responseException -> Mono.error<ClientResponse>(responseException) }
+        }.block()
+      }
+
+      assertEquals(1, requestCount.get())
+      assertContains(exception.message.orEmpty(), "400 Bad Request")
+    }
+
+    private fun clientRequest(): ClientRequest = ClientRequest.create(HttpMethod.GET, URI.create("http://localhost/oasys/12345/associations?planVersion=7")).build()
+
+    private fun exchangeFilterFunction() = webClientConfiguration.retryingExchangeFilterFunction()
+  }
+}
+
+private data class TestAssociationsResponse(
+  val sentencePlanId: UUID,
+  val sanAssessmentId: UUID,
+  val planVersion: Long,
+)


### PR DESCRIPTION
- Add 2 retries to WebClientConfiguration calls
- Add small amount of jitter to retry logic so that it doesn't cascade with other retries all at the same time