### PR TITLE
Fix context given name validation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/context/entity/HandoverContext.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/context/entity/HandoverContext.kt
@@ -85,11 +85,11 @@ data class SubjectDetails(
   val nomisId: String?,
   @field:Size(min = 1, max = 25)
   @field:AppSecAllowedCharacters
-  @field:Pattern(regexp = "^[a-zA-Z\\-']+$", message = "Given name must contain only alphabetic characters, hyphens, or apostrophes")
+  @field:Pattern(regexp = "^[a-zA-Z\\-' ]+$", message = "Given name must contain only alphabetic characters, hyphens, spaces, or apostrophes")
   val givenName: String,
   @field:Size(min = 1, max = 36)
   @field:AppSecAllowedCharacters
-  @field:Pattern(regexp = "^[a-zA-Z\\-'\\s]+$", message = "Family name must contain only alphabetic characters, hyphens, spaces, or apostrophes")
+  @field:Pattern(regexp = "^[a-zA-Z\\-' ]+$", message = "Family name must contain only alphabetic characters, hyphens, spaces, or apostrophes")
   val familyName: String,
   @field:Past
   val dateOfBirth: LocalDate?,


### PR DESCRIPTION
Looks like we have users with multiple given names, this fixes the validation to allow for that. Also looks like `\s` was allowing for empty or ` `, not sure if this was intended? I've swapped it out for a literal space