### PR TITLE
Allow forward slashes in SubjectDetails givenName and familyName

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/context/entity/HandoverContext.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/context/entity/HandoverContext.kt
@@ -85,11 +85,11 @@ data class SubjectDetails(
   val nomisId: String?,
   @field:Size(min = 1, max = 25)
   @field:AppSecAllowedCharacters
-  @field:Pattern(regexp = "^[a-zA-Z\\-' /]+$", message = "Given name must contain only alphabetic characters, hyphens, spaces, forward slashes, or apostrophes")
+  @field:Pattern(regexp = "^[a-zA-Z0-9\\-' /]+$", message = "Given name must contain only alphabetic characters, numbers, hyphens, spaces, forward slashes, or apostrophes")
   val givenName: String,
   @field:Size(min = 1, max = 36)
   @field:AppSecAllowedCharacters
-  @field:Pattern(regexp = "^[a-zA-Z\\-' /]+$", message = "Family name must contain only alphabetic characters, hyphens, spaces, forward slashes, or apostrophes")
+  @field:Pattern(regexp = "^[a-zA-Z0-9\\-' /]+$", message = "Family name must contain only alphabetic characters, numbers, hyphens, spaces, forward slashes, or apostrophes")
   val familyName: String,
   @field:Past
   val dateOfBirth: LocalDate?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/context/entity/HandoverContext.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessrisksandneedshandoverservice/context/entity/HandoverContext.kt
@@ -85,11 +85,11 @@ data class SubjectDetails(
   val nomisId: String?,
   @field:Size(min = 1, max = 25)
   @field:AppSecAllowedCharacters
-  @field:Pattern(regexp = "^[a-zA-Z\\-' ]+$", message = "Given name must contain only alphabetic characters, hyphens, spaces, or apostrophes")
+  @field:Pattern(regexp = "^[a-zA-Z\\-' /]+$", message = "Given name must contain only alphabetic characters, hyphens, spaces, forward slashes, or apostrophes")
   val givenName: String,
   @field:Size(min = 1, max = 36)
   @field:AppSecAllowedCharacters
-  @field:Pattern(regexp = "^[a-zA-Z\\-' ]+$", message = "Family name must contain only alphabetic characters, hyphens, spaces, or apostrophes")
+  @field:Pattern(regexp = "^[a-zA-Z\\-' /]+$", message = "Family name must contain only alphabetic characters, hyphens, spaces, forward slashes, or apostrophes")
   val familyName: String,
   @field:Past
   val dateOfBirth: LocalDate?,


### PR DESCRIPTION
Mirrors #222 (displayName) but for the subject's name fields. Allows '/' and 0-9 numbers in given/family names to support subjects with married/maiden surnames.