### PR TITLE
Enable ModSecurity WAF across all environments

### DIFF
--- a/helm_deploy/hmpps-assess-risks-and-needs-handover-service/values.yaml
+++ b/helm_deploy/hmpps-assess-risks-and-needs-handover-service/values.yaml
@@ -29,6 +29,8 @@ generic-service:
       SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.middleName"
       SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.preferredName"
       SecRuleUpdateTargetById 932260 "!ARGS:json.user.displayName"
+      # Block Detectify scanner with 418
+      SecRule REQUEST_HEADERS:User-Agent "@pm detectify Detectify DETECTIFY" "id:800003,phase:1,deny,status:418,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
       # No PHP in this service - disable PHP rules to reduce log noise from external scans
       SecRuleRemoveById 930130
       SecRuleRemoveById 933150

--- a/helm_deploy/hmpps-assess-risks-and-needs-handover-service/values.yaml
+++ b/helm_deploy/hmpps-assess-risks-and-needs-handover-service/values.yaml
@@ -15,8 +15,16 @@ generic-service:
     host: app-hostname.local # override per environment
     tlsSecretName: hmpps-assess-risks-and-needs-handover-service-cert
     modsecurity_enabled: true
+    modsecurity_audit_enabled: true
     modsecurity_snippet: |
+<<<<<<< Updated upstream
       SecRuleEngine DetectionOnly
+=======
+      SecRuleEngine On
+      # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
+      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
+      # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
+>>>>>>> Stashed changes
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"

--- a/helm_deploy/hmpps-assess-risks-and-needs-handover-service/values.yaml
+++ b/helm_deploy/hmpps-assess-risks-and-needs-handover-service/values.yaml
@@ -17,7 +17,7 @@ generic-service:
     modsecurity_enabled: true
     modsecurity_audit_enabled: true
     modsecurity_snippet: |
-      SecRuleEngine On
+      SecRuleEngine DetectionOnly
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
       # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives

--- a/helm_deploy/hmpps-assess-risks-and-needs-handover-service/values.yaml
+++ b/helm_deploy/hmpps-assess-risks-and-needs-handover-service/values.yaml
@@ -17,14 +17,22 @@ generic-service:
     modsecurity_enabled: true
     modsecurity_audit_enabled: true
     modsecurity_snippet: |
-<<<<<<< Updated upstream
-      SecRuleEngine DetectionOnly
-=======
       SecRuleEngine On
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
+      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
+      SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      # CRS 932260 (Unix RCE detection) false-positives on personal name fields in POST /handover
+      # Names like "Perf", "Cat", "Ed" overlap with Unix command names and trip the regex at paranoia level 1
+      SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.givenName"
+      SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.familyName"
+      SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.middleName"
+      SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.preferredName"
+      SecRuleUpdateTargetById 932260 "!ARGS:json.user.displayName"
+      # No PHP in this service - disable PHP rules to reduce log noise from external scans
+      SecRuleRemoveById 930130
+      SecRuleRemoveById 933150
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
->>>>>>> Stashed changes
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"


### PR DESCRIPTION
Enables ModSecurity WAF in **DetectionOnly** mode in **ALL** environments.

We tested this in dev with SecRuleEngine On (blocking mode) and confirmed:

- Malicious requests (XSS, scanner traffic) are correctly blocked with a 406 response
- Legitimate traffic is unaffected
- Detections are visible in [OpenSearch ](https://logs.cloud-platform.service.justice.gov.uk/_dashboards/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1h,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:b95d8900-dd15-11ed-87c8-170407f57c9c,key:github_teams,negate:!f,params:(query:hmpps-assessments),type:phrase),query:(match_phrase:(github_teams:hmpps-assessments)))),index:b95d8900-dd15-11ed-87c8-170407f57c9c,interval:auto,query:(language:kuery,query:''),sort:!()))under live_k8s_modsec_ingress-*, filterable by github_teams: hmpps-assessments

We also ran in DetectionOnly mode on test to validate that real-world attack traffic (including active Detectify subdomain scans) is being detected and logged correctly before enabling blocking.