### PR TITLE
Update values-test.yaml

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -12,6 +12,8 @@ generic-service:
       SecRuleEngine On
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
+      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
+      SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -14,6 +14,12 @@ generic-service:
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
       # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      # CRS 932260 (Unix RCE detection) false-positives on personal name fields in POST /handover
+      # Names like "Perf", "Cat", "Ed" overlap with Unix command names and trip the regex at paranoia level 1
+      SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.givenName"
+      SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.familyName"
+      SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.middleName"
+      SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.preferredName"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -12,6 +12,8 @@ generic-service:
       SecRuleEngine On
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
+      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
+      SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -14,6 +14,12 @@ generic-service:
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
       # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      # CRS 932260 (Unix RCE detection) false-positives on personal name fields in POST /handover
+      # Names like "Perf", "Cat", "Ed" overlap with Unix command names and trip the regex at paranoia level 1
+      SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.givenName"
+      SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.familyName"
+      SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.middleName"
+      SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.preferredName"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"


### PR DESCRIPTION
During smoke testing, ~17,000 blocked requests (406) were observed on the handover service in dev. The handover payload likely contains non-ASCII characters (accented names, Welsh characters etc.) which trigger OWASP CRS rule 920272 ("Invalid character in request outside printable ASCII"). The UI and API already have this exclusion in place for the same reason.

This PR adds SecRuleUpdateTargetById 920272 "!REQUEST_BODY" to the handover service helm values to exclude request body scanning, matching the rules already in the coordinator, UI and API