### PR TITLE
Enable ModSec WAF: blocking in dev/test, DetectionOnly in preprod/prod

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -6,6 +6,28 @@ generic-service:
 
   ingress:
     host: arns-handover-service-preprod.hmpps.service.justice.gov.uk
+    modsecurity_enabled: true
+    modsecurity_audit_enabled: true
+    modsecurity_snippet: |
+      SecRuleEngine DetectionOnly
+      # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
+      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
+      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
+      SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      # CRS 932260 (Unix RCE detection) false-positives on personal name fields in POST /handover
+      # Names like "Perf", "Cat", "Ed" overlap with Unix command names and trip the regex at paranoia level 1
+      SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.givenName"
+      SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.familyName"
+      SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.middleName"
+      SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.preferredName"
+      SecRuleUpdateTargetById 932260 "!ARGS:json.user.displayName"
+      # No PHP in this service - disable PHP rules to reduce log noise from external scans
+      SecRuleRemoveById 930130
+      SecRuleRemoveById 933150
+      # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
+      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   env:
     HMPPS_AUTH_BASE_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -6,6 +6,28 @@ generic-service:
 
   ingress:
     host: arns-handover-service.hmpps.service.justice.gov.uk
+    modsecurity_enabled: true
+    modsecurity_audit_enabled: true
+    modsecurity_snippet: |
+      SecRuleEngine DetectionOnly
+      # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
+      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
+      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
+      SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      # CRS 932260 (Unix RCE detection) false-positives on personal name fields in POST /handover
+      # Names like "Perf", "Cat", "Ed" overlap with Unix command names and trip the regex at paranoia level 1
+      SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.givenName"
+      SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.familyName"
+      SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.middleName"
+      SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.preferredName"
+      SecRuleUpdateTargetById 932260 "!ARGS:json.user.displayName"
+      # No PHP in this service - disable PHP rules to reduce log noise from external scans
+      SecRuleRemoveById 930130
+      SecRuleRemoveById 933150
+      # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
+      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   env:
     HMPPS_AUTH_BASE_URL: "https://sign-in.hmpps.service.justice.gov.uk"


### PR DESCRIPTION
Final WAF test configuration for the Handover Service.

Dev and test already enforce the existing WAF ruleset. This PR adds the same ruleset to preprod and prod in DetectionOnly (log-only) so we can observe what would be blocked against production-like traffic before enabling enforcement there.