### PR TITLE
Add Test environment back into pipeline

### DIFF
--- a/.github/workflows/pipeline_main.yml
+++ b/.github/workflows/pipeline_main.yml
@@ -55,6 +55,17 @@ jobs:
       environment: 'dev'
       app_version: '${{ needs.build_docker.outputs.app_version }}'
 
+  deploy_test:
+    name: Deploy to the test environment
+    needs:
+      - deploy_dev
+      - build_docker
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2
+    secrets: inherit
+    with:
+      environment: 'test'
+      app_version: '${{ needs.build_docker.outputs.app_version }}'
+
   deploy_preprod:
     name: Deploy to the preproduction environment
     needs:


### PR DESCRIPTION
- Adds a deploy_test job to the main pipeline so that merges to main are actually deployed to the test environment.                                                                              
                                                                                                                                                                                                 
- The main pipeline currently only deploys to dev, preprod and prod. Test only ever got updated if someone deployed it by hand.  This caused today's outage on the SAN/Sentence Plan TEST environments. A change from April that sets an expiry time on Redis data never reached test. Without it, handover data never expired, Redis filled up over three months, and this
morning it hit its memory limit and started rejecting every write so the handover service couldn't create sessions and SAN/SP test was unusable.                                                

- To avoid this in future we should keep Test up-to-date, after this change, Test will deploy after dev, at the same time as preprod. Test runs alongside preprod rather than in the chain, because test depends on external systems. If it were in the chain, a problem in test might block production releases.   