### PR TITLE
Disable 931100 ModSec rule in test environment

### DIFF
--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -21,6 +21,9 @@ generic-service:
       SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.middleName"
       SecRuleUpdateTargetById 932260 "!ARGS:json.subjectDetails.preferredName"
       SecRuleUpdateTargetById 932260 "!ARGS:json.user.displayName"
+      # CRS 931100 (RFI: URL param using IP address) false-positives on OASys's returnUrl,
+      # which in Test legitimately points to their on-prem integration box by IP (see OASYS_RETURN_URLS)
+      SecRuleUpdateTargetById 931100 "!ARGS:json.user.returnUrl"
       # No PHP in this service - disable PHP rules to reduce log noise from external scans
       SecRuleRemoveById 930130
       SecRuleRemoveById 933150


### PR DESCRIPTION
- OASys integration testing against Test was failing with 406 (ModSecurity block) on `POST /handover`                                                                                                
- Root cause: CRS rule 931100 ("RFI: URL param using IP address") false-positives on the `returnUrl` field, in Test, OASys's on-prem integration box is legitimately addressed by raw IP. (see `OASYS_RETURN_URL), which this rule treats as a threat
- Adds a targeted `SecRuleUpdateTargetById` exclusion for this one field.